### PR TITLE
fix: move Effect packages to peer dependencies

### DIFF
--- a/.changeset/flexible-dependencies.md
+++ b/.changeset/flexible-dependencies.md
@@ -1,0 +1,7 @@
+---
+"runtime-resolver": patch
+---
+
+## Other
+
+- Moved Effect packages from dependencies to peer dependencies for better deduplication in library consumers

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Resolve semver-compatible versions of Node.js, Bun and Deno runtimes. Fetches av
 npm install runtime-resolver
 ```
 
+The Effect packages (`effect`, `@effect/cli`, `@effect/platform`, `@effect/platform-node`) are declared as peer dependencies. npm 7+ and pnpm auto-install them by default. If you already use Effect in your project, your existing versions will be reused.
+
 ## Quick Start
 
 ```typescript
@@ -38,7 +40,7 @@ const bun = await resolveBun({ semverRange: ">=1.1", increments: "minor" });
 const deno = await resolveDeno({ semverRange: ">=2", increments: "minor" });
 ```
 
-Set a `GITHUB_TOKEN` or `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable for authenticated requests. Without one, the resolver falls back to cached data.
+Set a `GITHUB_PERSONAL_ACCESS_TOKEN` or `GITHUB_TOKEN` environment variable for authenticated requests. Without one, the resolver falls back to cached data.
 
 ### CLI
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,12 @@ npm install -g runtime-resolver
 npx runtime-resolver --node ">=20"
 ```
 
+### Peer Dependencies
+
+The Effect packages (`effect`, `@effect/cli`, `@effect/platform`, `@effect/platform-node`) are peer dependencies. When installing globally or via `npx`, npm 7+ and pnpm auto-install them automatically. No extra steps are needed.
+
+If you use `runtime-resolver` as a library alongside your own Effect project, your existing Effect versions are reused — avoiding duplicate instances that would break `Context.Tag` identity.
+
 ## Options
 
 | Flag | Description | Example |

--- a/package.json
+++ b/package.json
@@ -62,11 +62,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"dependencies": {
-		"@effect/cli": "catalog:silk",
-		"@effect/platform": "catalog:silk",
-		"@effect/platform-node": "catalog:silk",
 		"@octokit/auth-app": "^8.2.0",
-		"effect": "catalog:silk",
 		"octokit": "^5.0.5",
 		"semver-effect": "^0.2.1"
 	},
@@ -77,6 +73,12 @@
 		"@savvy-web/rslib-builder": "^0.20.1",
 		"@savvy-web/vitest": "^1.3.0",
 		"tsx": "catalog:silk"
+	},
+	"peerDependencies": {
+		"@effect/cli": "catalog:silkPeers",
+		"@effect/platform": "catalog:silkPeers",
+		"@effect/platform-node": "catalog:silkPeers",
+		"effect": "catalog:silkPeers"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"devEngines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,21 +6,22 @@ settings:
 
 catalogs:
   silk:
-    '@effect/cli':
-      specifier: ^0.75.0
-      version: 0.75.0
-    '@effect/platform':
-      specifier: ^0.96.0
-      version: 0.96.0
-    '@effect/platform-node':
-      specifier: ^0.106.0
-      version: 0.106.0
-    effect:
-      specifier: ^3.21.0
-      version: 3.21.0
     tsx:
       specifier: ^4.21.0
       version: 4.21.0
+  silkPeers:
+    '@effect/cli':
+      specifier: '>=0.75.0'
+      version: 0.75.0
+    '@effect/platform':
+      specifier: '>=0.96.0'
+      version: 0.96.0
+    '@effect/platform-node':
+      specifier: '>=0.106.0'
+      version: 0.106.0
+    effect:
+      specifier: '>=3.21.0'
+      version: 3.21.0
 
 overrides:
   '@isaacs/brace-expansion': ^5.0.1
@@ -37,19 +38,19 @@ importers:
   .:
     dependencies:
       '@effect/cli':
-        specifier: catalog:silk
+        specifier: catalog:silkPeers
         version: 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@effect/platform':
-        specifier: catalog:silk
+        specifier: catalog:silkPeers
         version: 0.96.0(effect@3.21.0)
       '@effect/platform-node':
-        specifier: catalog:silk
+        specifier: catalog:silkPeers
         version: 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@octokit/auth-app':
         specifier: ^8.2.0
         version: 8.2.0
       effect:
-        specifier: catalog:silk
+        specifier: catalog:silkPeers
         version: 3.21.0
       octokit:
         specifier: ^5.0.5


### PR DESCRIPTION
## Summary

- Moved `effect`, `@effect/cli`, `@effect/platform`, and `@effect/platform-node` from `dependencies` to `peerDependencies` with broad `catalog:silkPeers` ranges
- Library consumers can bring their own compatible Effect versions, avoiding duplicate instances that break `Context.Tag` identity
- npm 7+ and pnpm auto-install peers for CLI and `npx` users

## Test plan

- [ ] Verify `pnpm install` resolves peers via `autoInstallPeers`
- [ ] Verify `pnpm run typecheck` passes
- [ ] Verify `pnpm run test` passes
- [ ] Verify `pnpm run build:prod` produces correct `peerDependencies` in `dist/npm/package.json`

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>